### PR TITLE
Bump version to 4.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # ebean-hazelcast
 Hazelcast L2 cache option
+
+# How to build and test
+
+To run the unit tests, start a local hazelcast docker container
+
+    docker run -p 5701:5701 hazelcast/hazelcast:4.0.6
+    
+maven build with
+
+    mvn clean install
+

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   </scm>
 
   <properties>
-    <hazelcast.version>4.0.6</hazelcast.version>
+    <hazelcast.version>4.1.5</hazelcast.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>io.ebean</groupId>
   <artifactId>ebean-hazelcast</artifactId>
-  <version>12.11.0</version>
+  <version>12.11.1-SNAPSHOT</version>
 
   <scm>
     <developerConnection>scm:git:git@github.com:ebean-orm/ebean-hazelcast.git</developerConnection>
@@ -18,16 +18,16 @@
   </scm>
 
   <properties>
-    <hazelcast.version>4.0.5</hazelcast.version>
+    <hazelcast.version>4.0.6</hazelcast.version>
   </properties>
 
   <dependencies>
-
-    <dependency>
+<!-- client is in hazelcast.jar up to 4.0, see https://docs.hazelcast.org/docs/4.0/manual/html-single/#upgrading-to-hazelcast-imdg-4-0 -->
+  <!--    <dependency>
       <groupId>com.hazelcast</groupId>
       <artifactId>hazelcast-client</artifactId>
       <version>${hazelcast.version}</version>
-    </dependency>
+    </dependency> -->
 
     <dependency>
       <groupId>com.hazelcast</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   </scm>
 
   <properties>
-    <hazelcast.version>3.12.12</hazelcast.version>
+    <hazelcast.version>4.0.5</hazelcast.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -22,12 +22,6 @@
   </properties>
 
   <dependencies>
-<!-- client is in hazelcast.jar up to 4.0, see https://docs.hazelcast.org/docs/4.0/manual/html-single/#upgrading-to-hazelcast-imdg-4-0 -->
-  <!--    <dependency>
-      <groupId>com.hazelcast</groupId>
-      <artifactId>hazelcast-client</artifactId>
-      <version>${hazelcast.version}</version>
-    </dependency> -->
 
     <dependency>
       <groupId>com.hazelcast</groupId>
@@ -38,7 +32,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean</artifactId>
-      <version>12.11.1</version>
+      <version>12.15.0</version>
       <scope>provided</scope>
     </dependency>
 
@@ -52,7 +46,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-test</artifactId>
-      <version>12.11.1</version>
+      <version>12.15.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/main/java/io/ebean/hazelcast/HzCache.java
+++ b/src/main/java/io/ebean/hazelcast/HzCache.java
@@ -1,6 +1,5 @@
 package io.ebean.hazelcast;
 
-import com.hazelcast.core.IMap;
 import io.ebean.cache.ServerCache;
 import io.ebean.cache.ServerCacheStatistics;
 import io.ebean.cache.TenantAwareKey;
@@ -8,6 +7,8 @@ import io.ebean.config.CurrentTenantProvider;
 
 import java.util.Map;
 import java.util.Set;
+
+import com.hazelcast.map.IMap;
 
 /**
  * IMap cache implementation for Ebean ServerCache interface.

--- a/src/main/java/io/ebean/hazelcast/HzCacheFactory.java
+++ b/src/main/java/io/ebean/hazelcast/HzCacheFactory.java
@@ -5,8 +5,9 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
-import com.hazelcast.core.ITopic;
+import com.hazelcast.map.IMap;
+import com.hazelcast.topic.ITopic;
+
 import io.ebean.BackgroundExecutor;
 import io.ebean.cache.ServerCache;
 import io.ebean.cache.ServerCacheConfig;

--- a/src/main/java/io/ebean/hazelcast/HzServerCacheNotify.java
+++ b/src/main/java/io/ebean/hazelcast/HzServerCacheNotify.java
@@ -1,10 +1,11 @@
 package io.ebean.hazelcast;
 
-import com.hazelcast.core.ITopic;
 import io.ebean.cache.ServerCacheNotification;
 import io.ebean.cache.ServerCacheNotify;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.hazelcast.topic.ITopic;
 
 import java.util.Set;
 

--- a/src/test/java/org/integration/ClientTest.java
+++ b/src/test/java/org/integration/ClientTest.java
@@ -5,11 +5,13 @@ import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
-import org.example.domain.ECustomer;
+import com.hazelcast.map.IMap;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
+
+import org.example.domain.ECustomer;
 
 public class ClientTest {
 

--- a/src/test/resources/hazelcast-client.xml
+++ b/src/test/resources/hazelcast-client.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config https://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.0.xsd"
+<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config https://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.1.xsd"
            xmlns="http://www.hazelcast.com/schema/client-config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 

--- a/src/test/resources/hazelcast-client.xml
+++ b/src/test/resources/hazelcast-client.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config http://www.hazelcast.com/hazelcast-client-config-3.6.xsd"
+<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config https://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.0.xsd"
            xmlns="http://www.hazelcast.com/schema/client-config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 

--- a/src/test/resources/hazelcast.xml
+++ b/src/test/resources/hazelcast.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/hazelcast-config-3.6.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config https://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
            xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
@@ -16,8 +16,8 @@
     <async-backup-count>0</async-backup-count>
     <time-to-live-seconds>0</time-to-live-seconds>
     <max-idle-seconds>0</max-idle-seconds>
-    <eviction-policy>NONE</eviction-policy>
-    <max-size policy="PER_NODE">0</max-size>
+ <!--     <eviction-policy>NONE</eviction-policy> 
+    <max-size policy="PER_NODE">0</max-size> -->
   </map>
 
 </hazelcast>

--- a/src/test/resources/hazelcast.xml
+++ b/src/test/resources/hazelcast.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config https://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config https://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd"
            xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 

--- a/src/test/resources/hazelcast.xml
+++ b/src/test/resources/hazelcast.xml
@@ -16,8 +16,6 @@
     <async-backup-count>0</async-backup-count>
     <time-to-live-seconds>0</time-to-live-seconds>
     <max-idle-seconds>0</max-idle-seconds>
- <!--     <eviction-policy>NONE</eviction-policy> 
-    <max-size policy="PER_NODE">0</max-size> -->
   </map>
 
 </hazelcast>


### PR DESCRIPTION
Hello @rbygrave ,

we would like to use distributed caches in our application. We are now experimenting with Hazelcast & Apache Ignite.
We would like to use a newer version of Hazelcast: 4.1.5.

The upgrade would be ready: some imports are modified, because the hazelcast-client.jar is now integrated in hazelcast.jar: https://docs.hazelcast.org/docs/rn/index.html#4-0

A small code change is needed in ebean, because the cache map of Hazelcast is now an UnmodifiedMap. I will also open a PR for this change.

Kind regards
Noemi