### PR TITLE
Bug: TenanAwareKey vs not tenant aware keys in cache

### DIFF
--- a/src/main/java/io/ebean/hazelcast/HzCache.java
+++ b/src/main/java/io/ebean/hazelcast/HzCache.java
@@ -2,8 +2,6 @@ package io.ebean.hazelcast;
 
 import io.ebean.cache.ServerCache;
 import io.ebean.cache.ServerCacheStatistics;
-import io.ebean.cache.TenantAwareKey;
-import io.ebean.config.CurrentTenantProvider;
 
 import java.util.Map;
 import java.util.Set;
@@ -15,16 +13,10 @@ import com.hazelcast.map.IMap;
  */
 final class HzCache implements ServerCache {
 
-  private final TenantAwareKey tenantAwareKey;
   private final IMap<Object, Object> map;
 
-  HzCache(IMap<Object, Object> map, CurrentTenantProvider tenantProvider) {
+  HzCache(IMap<Object, Object> map) {
     this.map = map;
-    this.tenantAwareKey = new TenantAwareKey(tenantProvider);
-  }
-
-  private Object key(Object key) {
-    return tenantAwareKey.key(key);
   }
 
   @Override
@@ -39,17 +31,17 @@ final class HzCache implements ServerCache {
 
   @Override
   public Object get(Object id) {
-    return map.get(key(id));
+    return map.get(id);
   }
 
   @Override
   public void put(Object id, Object value) {
-    map.put(key(id), value);
+    map.put(id, value);
   }
 
   @Override
   public void remove(Object id) {
-    map.delete(key(id));
+    map.delete(id);
   }
 
   @Override

--- a/src/main/java/io/ebean/hazelcast/HzCacheFactory.java
+++ b/src/main/java/io/ebean/hazelcast/HzCacheFactory.java
@@ -14,6 +14,7 @@ import io.ebean.cache.ServerCacheConfig;
 import io.ebean.cache.ServerCacheFactory;
 import io.ebean.cache.ServerCacheNotification;
 import io.ebean.cache.ServerCacheNotify;
+import io.ebean.cache.TenantAwareKey;
 import io.ebean.config.DatabaseConfig;
 import io.ebeaninternal.server.cache.DefaultServerCacheConfig;
 import io.ebeaninternal.server.cache.DefaultServerQueryCache;
@@ -118,7 +119,12 @@ public final class HzCacheFactory implements ServerCacheFactory {
     String fullName = config.getType().name() + "-" + config.getCacheKey();
     logger.debug("get cache [{}]", fullName);
     IMap<Object, Object> map = instance.getMap(fullName);
-    return new HzCache(map, config.getTenantProvider());
+    ServerCache hzCache = new HzCache(map);
+    if (config.getTenantProvider() != null) {
+      return new TenantAwareCache(hzCache, new TenantAwareKey(config.getTenantProvider()));
+    } else  {
+      return hzCache;
+    }
   }
 
   private ServerCache createQueryCache(ServerCacheConfig config) {

--- a/src/main/java/io/ebean/hazelcast/TenantAwareCache.java
+++ b/src/main/java/io/ebean/hazelcast/TenantAwareCache.java
@@ -1,0 +1,82 @@
+package io.ebean.hazelcast;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import io.ebean.cache.ServerCache;
+import io.ebean.cache.ServerCacheStatistics;
+import io.ebean.cache.TenantAwareKey;
+
+public class TenantAwareCache implements ServerCache {
+
+  private final ServerCache delegate;
+  private final TenantAwareKey tenantAwareKey;
+  
+  public TenantAwareCache(ServerCache delegate, TenantAwareKey tenantAwareKey) {
+    this.delegate = delegate;
+    this.tenantAwareKey = tenantAwareKey;
+  }
+
+  private Object key(Object key) {
+    return tenantAwareKey.key(key);
+  }
+  @Override
+  public Object get(Object id) {
+    return delegate.get(key(id));
+  }
+
+  @Override
+  public void put(Object id, Object value) {
+    delegate.put(key(id), value);
+  }
+
+  @Override
+  public void remove(Object id) {
+    delegate.remove(key(id));
+  }
+
+  @Override
+  public void clear() {
+    delegate.clear();
+  }
+
+  @Override
+  public int size() {
+    return delegate.size();
+  }
+
+  @Override
+  public int getHitRatio() {
+    return delegate.getHitRatio();
+  }
+
+  @Override
+  public ServerCacheStatistics getStatistics(boolean reset) {
+    return delegate.getStatistics(reset);
+  }
+  
+  @Override
+  public Map<Object, Object> getAll(Set<Object> keys) {
+    Map<Object, Object> keyMapping = new HashMap<>();
+    keys.forEach(k -> keyMapping.put(key(k),k));
+    Map<Object, Object> tmp = delegate.getAll(keyMapping.keySet());
+    Map<Object, Object> ret = new HashMap<Object, Object>();
+    tmp.forEach((k,v)-> ret.put(keyMapping.get(k), v)); // remove tenant info here
+    return ret;
+  }
+
+  @Override
+  public void putAll(Map<Object, Object> keyValues) {
+    Map<Object, Object> tmp = new HashMap<Object, Object>();
+    keyValues.forEach((k,v)-> tmp.put(key(k), v)); 
+    delegate.putAll(tmp);
+  }
+  
+  @Override
+  public void removeAll(Set<Object> keys) {
+    delegate.removeAll(keys.stream().map(this::key).collect(Collectors.toSet()));
+  }
+  
+}


### PR DESCRIPTION
Hello @rbygrave ,

@rpraml and I tested our application in a multi tomcat environment with hazelcast and we got some problems by caching (login of a user).

From an user-password entity we had 2 entries in the cache map: one with the UUID as key (e.g. 1234) and the second one used the TenantAwareKey (e.g. 1234:1, :1 as the tenant information)  --> Our next query wanted to load the entity from the cache but it got the "wrong" one without the tenant information which was outdated (--> our login was not successful because it used the old password).

@rpraml implemented a temporary solution that works in our application.